### PR TITLE
default to the set content type default in settings

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -1,6 +1,11 @@
 Version History
 ===============
 
+`1.0.4`_ (14 Sep 2015)
+---------------------
+- Support using the default_content_type in the settings if request does not
+  contain the Accept header
+
 `1.0.3`_ (10 Sep 2015)
 ---------------------
 - Update installation files
@@ -17,6 +22,7 @@ Version History
 ---------------------
 - Initial Release
 
+.. _1.0.4: https://github.com/sprockets/sprockets.http/compare/1.0.3...1.0.4
 .. _1.0.3: https://github.com/sprockets/sprockets.http/compare/1.0.2...1.0.3
 .. _1.0.2: https://github.com/sprockets/sprockets.http/compare/1.0.1...1.0.2
 .. _1.0.1: https://github.com/sprockets/sprockets.http/compare/1.0.0...1.0.1

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ tests_require = read_requirements('testing.txt')
 
 setuptools.setup(
     name='sprockets.mixins.mediatype',
-    version='1.0.3',
+    version='1.0.4',
     description='A mixin for reporting handling content-type/accept headers',
     long_description='\n' + open('README.rst').read(),
     url='https://github.com/sprockets/sprockets.mixins.media_type',

--- a/sprockets/mixins/mediatype.py
+++ b/sprockets/mixins/mediatype.py
@@ -9,7 +9,7 @@ from ietfparse import algorithms, errors, headers
 from tornado import escape, web
 
 
-version_info = (1, 0, 3)
+version_info = (1, 0, 4)
 __version__ = '.'.join(str(v) for v in version_info)
 logger = logging.getLogger(__name__)
 

--- a/sprockets/mixins/mediatype.py
+++ b/sprockets/mixins/mediatype.py
@@ -178,7 +178,10 @@ class ContentMixin(object):
         if self._best_response_match is None:
             settings = ContentSettings.from_application(self.application)
             acceptable = headers.parse_http_accept_header(
-                self.request.headers.get('Accept', '*/*'))
+                self.request.headers.get(
+                    'Accept',
+                    settings.default_content_type
+                    if settings.default_content_type else '*/*'))
             try:
                 selected, _ = algorithms.select_content_type(
                     acceptable, settings.available_content_types)

--- a/tests.py
+++ b/tests.py
@@ -34,6 +34,13 @@ class SendResponseTests(testing.AsyncHTTPTestCase):
         self.assertEqual(response.headers['Content-Type'],
                          'application/msgpack')
 
+    def test_that_default_content_type_is_set_on_response(self):
+        response = self.fetch('/', method='POST', body=msgpack.packb('{}'),
+                              headers={'Content-Type': 'application/msgpack'})
+        self.assertEqual(response.code, 200)
+        self.assertEqual(response.headers['Content-Type'],
+                         'application/json; charset="utf-8"')
+
 
 class GetRequestBodyTests(testing.AsyncHTTPTestCase):
 


### PR DESCRIPTION
When getting the accept headers from the handler's request, default to the applications' settings default_content_type.