### PR TITLE
Remove recursive unicode

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -2,12 +2,12 @@ Version History
 ===============
 
 `1.0.4`_ (14 Sep 2015)
----------------------
+----------------------
 - Support using the default_content_type in the settings if request does not
   contain the Accept header
 
 `1.0.3`_ (10 Sep 2015)
----------------------
+----------------------
 - Update installation files
 
 `1.0.2`_ (9 Sep 2015)

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -1,6 +1,11 @@
 Version History
 ===============
 
+`Next Release`_
+---------------
+- Replace ``tornado.escape.recursive_unicode`` with using the
+  `coercion`_ package instead
+
 `1.0.4`_ (14 Sep 2015)
 ----------------------
 - Support using the default_content_type in the settings if request does not
@@ -22,8 +27,12 @@ Version History
 ---------------------
 - Initial Release
 
+.. _Next Release: https://github.com/sprockets/sprockets.http/compare/1.0.4...master
+
 .. _1.0.4: https://github.com/sprockets/sprockets.http/compare/1.0.3...1.0.4
 .. _1.0.3: https://github.com/sprockets/sprockets.http/compare/1.0.2...1.0.3
 .. _1.0.2: https://github.com/sprockets/sprockets.http/compare/1.0.1...1.0.2
 .. _1.0.1: https://github.com/sprockets/sprockets.http/compare/1.0.0...1.0.1
 .. _1.0.0: https://github.com/sprockets/sprockets.http/compare/0.0.0...1.0.0
+
+.. _coercion: https://coercion.readthedocs.org/

--- a/requires/installation.txt
+++ b/requires/installation.txt
@@ -1,2 +1,3 @@
+coercion>=1.0.0,<2
 ietfparse>=1.2.2,<2
 tornado>=3.2,<5

--- a/sprockets/mixins/mediatype.py
+++ b/sprockets/mixins/mediatype.py
@@ -6,7 +6,8 @@ sprockets.mixins.media_type
 import logging
 
 from ietfparse import algorithms, errors, headers
-from tornado import escape, web
+from tornado import web
+import coercion
 
 
 version_info = (1, 0, 4)
@@ -259,7 +260,7 @@ class _TextContentHandler(object):
     def to_bytes(self, data_dict, encoding=None):
         selected = encoding or self.default_encoding
         content_type = '{0}; charset="{1}"'.format(self.content_type, selected)
-        dumped = self._dumps(escape.recursive_unicode(data_dict))
+        dumped = self._dumps(coercion.normalize_collection(data_dict))
         return content_type, dumped.encode(selected)
 
     def from_bytes(self, data, encoding=None):

--- a/tests.py
+++ b/tests.py
@@ -1,8 +1,12 @@
+from __future__ import print_function
+
 import json
+import unittest
 
 from tornado import testing
 import msgpack
 
+from sprockets.mixins import mediatype
 import examples
 
 
@@ -66,3 +70,32 @@ class GetRequestBodyTests(testing.AsyncHTTPTestCase):
                               headers={'Content-Type': 'application/msgpack'})
         self.assertEqual(response.code, 200)
         self.assertEqual(json.loads(response.body.decode('utf-8')), body)
+
+
+class RegressionTests(unittest.TestCase):
+
+    def test_that_deeply_nested_json_is_supported(self):
+        # this generates as deeply nested of a JSON document as the
+        # underlying json.dumps can handle
+        depth = 0
+        nested = {'nested': 'dict'}
+        while True:
+            try:
+                parent = {'nested': nested}
+
+                def f():
+                    def g():
+                        json.dumps(parent)
+                    g()
+                f()
+                nested = parent
+                depth += 1
+            except RuntimeError:
+                break
+        print('this implementation can handle', depth, 'nesting levels')
+
+        handler = mediatype._TextContentHandler('application/json',
+                                                json.dumps, json.loads,
+                                                'utf-8')
+        _, encoded = handler.to_bytes(nested)
+        self.assertEqual(handler.from_bytes(encoded), nested)

--- a/tests.py
+++ b/tests.py
@@ -35,7 +35,7 @@ class SendResponseTests(testing.AsyncHTTPTestCase):
                          'application/msgpack')
 
     def test_that_default_content_type_is_set_on_response(self):
-        response = self.fetch('/', method='POST', body=msgpack.packb('{}'),
+        response = self.fetch('/', method='POST', body=msgpack.packb({}),
                               headers={'Content-Type': 'application/msgpack'})
         self.assertEqual(response.code, 200)
         self.assertEqual(response.headers['Content-Type'],


### PR DESCRIPTION
This PR fixes an explosion that could occur with deeply nested JSON documents.  The underlying `tornado.escape.recursive_unicode` explodes at a depth of 984 items and `json.dumps` seems to fail around a depth of 945.  In practice, I was seeing failures at about a depth of 450 inside of application code.  In any case, recursive evaluation of a nested data structure is something that we should avoid whenever possible.  This PR uses the [coercion](https://coercion.readthedocs.org/) library to eliminate the unnecessary recursion.