### PR TITLE
Add pluggable transcoders

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,8 +12,8 @@ This mix-in adds two methods to a ``tornado.web.RequestHandler`` instance:
 - ``send_response(object)``: serializes the response into the content type
   requested by the ``Accept`` header.
 
-Support for a content types is enabled by calling either the
-``add_binary_content_type`` or ``add_text_content_type`` function with the
+Support for a content types is enabled by calling ``add_binary_content_type``,
+``add_text_content_type`` or the ``add_transcoder`` functions with the
 ``tornado.web.Application`` instance, the content type, encoding and decoding
 functions as parameters:
 
@@ -37,6 +37,29 @@ functions as parameters:
 
 The *add content type* functions will add a attribute to the ``Application``
 instance that the mix-in uses to manipulate the request and response bodies.
+The *add_transcoder* function is similar except that it takes an object
+that implements transcoding methods instead of simple functions.  The
+``transcoders`` module includes ready-to-use transcoders for a few content
+types:
+
+.. code-block:: python
+
+   from sprockets.mixins.mediatype import content, transcoders
+   from tornado import web
+
+   def make_application():
+       application = web.Application([
+           # insert your handlers here
+       ])
+
+       content.add_transcoder(application, 'application/json',
+                              transcoders.JSONTranscoder())
+
+       return application
+
+In either case, the ``ContentMixin`` uses the registered content type
+information to provide transparent content type negotiation for your
+request handlers.
 
 .. code-block:: python
 

--- a/README.rst
+++ b/README.rst
@@ -52,8 +52,7 @@ types:
            # insert your handlers here
        ])
 
-       content.add_transcoder(application, transcoders.JSONTranscoder(),
-                              'application/json')
+       content.add_transcoder(application, transcoders.JSONTranscoder())
 
        return application
 

--- a/README.rst
+++ b/README.rst
@@ -52,8 +52,8 @@ types:
            # insert your handlers here
        ])
 
-       content.add_transcoder(application, 'application/json',
-                              transcoders.JSONTranscoder())
+       content.add_transcoder(application, transcoders.JSONTranscoder(),
+                              'application/json')
 
        return application
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -19,3 +19,10 @@ Content Type Registration
 
 .. autoclass:: ContentSettings
    :members:
+
+Bundled Transcoders
+-------------------
+.. currentmodule:: sprockets.mixins.mediatype.transcoders
+
+.. autoclass:: JSONTranscoder
+   :members:

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -26,3 +26,6 @@ Bundled Transcoders
 
 .. autoclass:: JSONTranscoder
    :members:
+
+.. autoclass:: MsgPackTranscoder
+   :members:

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -29,3 +29,6 @@ Bundled Transcoders
 
 .. autoclass:: MsgPackTranscoder
    :members:
+
+.. autoclass:: BinaryWrapper
+   :members:

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -15,5 +15,7 @@ Content Type Registration
 
 .. autofunction:: add_text_content_type
 
+.. autofunction:: add_transcoder
+
 .. autoclass:: ContentSettings
    :members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,7 +31,7 @@ html_theme_options = {
 }
 
 intersphinx_mapping = {
-    'python': ('https://docs.python.org/', None),
+    'python': ('https://docs.python.org/3', None),
     'requests': ('https://requests.readthedocs.org/en/latest/', None),
     'sprockets': ('https://sprockets.readthedocs.org/en/latest/', None),
     'tornado': ('http://tornadoweb.org/en/latest/', None),

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -5,6 +5,7 @@ Version History
 ---------------
 - Repackage from a module into a package.  Distributing raw modules inside
   of a namespace package is unreliable and questionably correct.
+- Add :func:`sprockets.mixins.mediatype.content.add_transcoder`.
 
 `1.0.4`_ (14 Sep 2015)
 ----------------------

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -7,6 +7,7 @@ Version History
   of a namespace package is unreliable and questionably correct.
 - Add :func:`sprockets.mixins.mediatype.content.add_transcoder`.
 - Add :class:`sprockets.mixins.mediatype.transcoders.JSONTranscoder`
+- Add :class:`sprockets.mixins.mediatype.transcoders.MsgPackTranscoder`
 
 `1.0.4`_ (14 Sep 2015)
 ----------------------

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -9,6 +9,7 @@ Version History
 - Add :class:`sprockets.mixins.mediatype.transcoders.JSONTranscoder`
 - Add :class:`sprockets.mixins.mediatype.transcoders.MsgPackTranscoder`
 - Add :class:`sprockets.mixins.mediatype.transcoders.BinaryWrapper`
+- Normalize registered MIME types.
 
 `1.0.4`_ (14 Sep 2015)
 ----------------------

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -8,6 +8,7 @@ Version History
 - Add :func:`sprockets.mixins.mediatype.content.add_transcoder`.
 - Add :class:`sprockets.mixins.mediatype.transcoders.JSONTranscoder`
 - Add :class:`sprockets.mixins.mediatype.transcoders.MsgPackTranscoder`
+- Add :class:`sprockets.mixins.mediatype.transcoders.BinaryWrapper`
 
 `1.0.4`_ (14 Sep 2015)
 ----------------------

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -6,6 +6,7 @@ Version History
 - Repackage from a module into a package.  Distributing raw modules inside
   of a namespace package is unreliable and questionably correct.
 - Add :func:`sprockets.mixins.mediatype.content.add_transcoder`.
+- Add :class:`sprockets.mixins.mediatype.transcoders.JSONTranscoder`
 
 `1.0.4`_ (14 Sep 2015)
 ----------------------

--- a/examples.py
+++ b/examples.py
@@ -18,10 +18,8 @@ def make_application(**settings):
     application = web.Application([web.url(r'/', SimpleHandler)], **settings)
     content.set_default_content_type(application, 'application/json',
                                      encoding='utf-8')
-    content.add_transcoder(application, transcoders.MsgPackTranscoder(),
-                           content_type='application/msgpack')
-    content.add_transcoder(application, transcoders.JSONTranscoder(),
-                           content_type='application/json')
+    content.add_transcoder(application, transcoders.MsgPackTranscoder())
+    content.add_transcoder(application, transcoders.JSONTranscoder())
     return application
 
 

--- a/examples.py
+++ b/examples.py
@@ -3,7 +3,6 @@ import signal
 
 from sprockets.mixins.mediatype import content, transcoders
 from tornado import ioloop, web
-import msgpack
 
 
 class SimpleHandler(content.ContentMixin, web.RequestHandler):
@@ -19,8 +18,8 @@ def make_application(**settings):
     application = web.Application([web.url(r'/', SimpleHandler)], **settings)
     content.set_default_content_type(application, 'application/json',
                                      encoding='utf-8')
-    content.add_binary_content_type(application, 'application/msgpack',
-                                    msgpack.packb, msgpack.unpackb)
+    content.add_transcoder(application, 'application/msgpack',
+                           transcoders.MsgPackTranscoder())
     content.add_transcoder(application, 'application/json',
                            transcoders.JSONTranscoder())
     return application

--- a/examples.py
+++ b/examples.py
@@ -18,10 +18,10 @@ def make_application(**settings):
     application = web.Application([web.url(r'/', SimpleHandler)], **settings)
     content.set_default_content_type(application, 'application/json',
                                      encoding='utf-8')
-    content.add_transcoder(application, 'application/msgpack',
-                           transcoders.MsgPackTranscoder())
-    content.add_transcoder(application, 'application/json',
-                           transcoders.JSONTranscoder())
+    content.add_transcoder(application, transcoders.MsgPackTranscoder(),
+                           content_type='application/msgpack')
+    content.add_transcoder(application, transcoders.JSONTranscoder(),
+                           content_type='application/json')
     return application
 
 

--- a/examples.py
+++ b/examples.py
@@ -1,8 +1,7 @@
-import json
 import logging
 import signal
 
-from sprockets.mixins.mediatype import content
+from sprockets.mixins.mediatype import content, transcoders
 from tornado import ioloop, web
 import msgpack
 
@@ -22,8 +21,8 @@ def make_application(**settings):
                                      encoding='utf-8')
     content.add_binary_content_type(application, 'application/msgpack',
                                     msgpack.packb, msgpack.unpackb)
-    content.add_text_content_type(application, 'application/json', 'utf-8',
-                                  json.dumps, json.loads)
+    content.add_transcoder(application, 'application/json',
+                           transcoders.JSONTranscoder())
     return application
 
 

--- a/requires/testing.txt
+++ b/requires/testing.txt
@@ -1,4 +1,4 @@
 coverage>=3.7,<3.99  # prevent installing 4.0b on ALL pip versions
 mock>=1.3,<2
-msgpack-python>=0.4,<0.5
+u-msgpack-python>=2,<3
 nose>=1.3,<2

--- a/sprockets/mixins/mediatype/content.py
+++ b/sprockets/mixins/mediatype/content.py
@@ -148,9 +148,15 @@ def add_text_content_type(application, content_type, default_encoding,
     :param loads: function that loads a dictionary from a string.
         ``loads(str, encoding:str) -> dict``
 
+    Note that the ``charset`` parameter is stripped from `content_type`
+    if it is present.
+
     """
-    add_transcoder(application, content_type,
-                   handlers.TextContentHandler(content_type, dumps, loads,
+    parsed = headers.parse_content_type(content_type)
+    parsed.parameters.pop('charset', None)
+    normalized = str(parsed)
+    add_transcoder(application, normalized,
+                   handlers.TextContentHandler(normalized, dumps, loads,
                                                default_encoding))
 
 

--- a/sprockets/mixins/mediatype/content.py
+++ b/sprockets/mixins/mediatype/content.py
@@ -131,8 +131,9 @@ def add_binary_content_type(application, content_type, pack, unpack):
         dictionary.  ``unpack(bytes) -> dict``
 
     """
-    add_transcoder(application, content_type,
-                   handlers.BinaryContentHandler(content_type, pack, unpack))
+    add_transcoder(application,
+                   handlers.BinaryContentHandler(content_type, pack, unpack),
+                   content_type)
 
 
 def add_text_content_type(application, content_type, default_encoding,
@@ -155,19 +156,20 @@ def add_text_content_type(application, content_type, default_encoding,
     parsed = headers.parse_content_type(content_type)
     parsed.parameters.pop('charset', None)
     normalized = str(parsed)
-    add_transcoder(application, normalized,
+    add_transcoder(application,
                    handlers.TextContentHandler(normalized, dumps, loads,
-                                               default_encoding))
+                                               default_encoding),
+                   normalized)
 
 
-def add_transcoder(application, content_type, transcoder):
+def add_transcoder(application, transcoder, content_type):
     """
     Register a transcoder for a specific content type.
 
     :param tornado.web.Application application: the application to modify
-    :param str content_type: the content type to add
     :param transcoder: object that translates between :class:`bytes` and
         :class:`object` instances
+    :param str content_type: the content type to add
 
     The `transcoder` instance is required to implement the following
     simple protocol:

--- a/sprockets/mixins/mediatype/content.py
+++ b/sprockets/mixins/mediatype/content.py
@@ -132,8 +132,7 @@ def add_binary_content_type(application, content_type, pack, unpack):
 
     """
     add_transcoder(application,
-                   handlers.BinaryContentHandler(content_type, pack, unpack),
-                   content_type)
+                   handlers.BinaryContentHandler(content_type, pack, unpack))
 
 
 def add_text_content_type(application, content_type, default_encoding,
@@ -158,21 +157,27 @@ def add_text_content_type(application, content_type, default_encoding,
     normalized = str(parsed)
     add_transcoder(application,
                    handlers.TextContentHandler(normalized, dumps, loads,
-                                               default_encoding),
-                   normalized)
+                                               default_encoding))
 
 
-def add_transcoder(application, transcoder, content_type):
+def add_transcoder(application, transcoder, content_type=None):
     """
     Register a transcoder for a specific content type.
 
     :param tornado.web.Application application: the application to modify
     :param transcoder: object that translates between :class:`bytes` and
         :class:`object` instances
-    :param str content_type: the content type to add
+    :param str content_type: the content type to add.  If this is
+        unspecified or :data:`None`, then the transcoder's ``content_type``
+        attribute is used.
 
     The `transcoder` instance is required to implement the following
     simple protocol:
+
+    .. attribute:: transcoder.content_type
+
+       :class:`str` that identifies the MIME type that the transcoder
+       implements.
 
     .. method:: transcoder.to_bytes(inst_data, encoding=None) -> bytes
 
@@ -188,7 +193,7 @@ def add_transcoder(application, transcoder, content_type):
 
     """
     settings = ContentSettings.from_application(application)
-    settings[content_type] = transcoder
+    settings[content_type or transcoder.content_type] = transcoder
 
 
 def set_default_content_type(application, content_type, encoding=None):

--- a/sprockets/mixins/mediatype/content.py
+++ b/sprockets/mixins/mediatype/content.py
@@ -88,7 +88,7 @@ class ContentSettings(object):
     def __setitem__(self, content_type, handler):
         if content_type in self._handlers:
             logger.warning('handler for %s already set to %r',
-                           content_type, self._handers[content_type])
+                           content_type, self._handlers[content_type])
             return
 
         self._available_types.append(headers.parse_content_type(content_type))

--- a/sprockets/mixins/mediatype/content.py
+++ b/sprockets/mixins/mediatype/content.py
@@ -83,15 +83,18 @@ class ContentSettings(object):
         self.default_encoding = None
 
     def __getitem__(self, content_type):
-        return self._handlers[content_type]
+        parsed = headers.parse_content_type(content_type)
+        return self._handlers[str(parsed)]
 
     def __setitem__(self, content_type, handler):
+        parsed = headers.parse_content_type(content_type)
+        content_type = str(parsed)
         if content_type in self._handlers:
             logger.warning('handler for %s already set to %r',
                            content_type, self._handlers[content_type])
             return
 
-        self._available_types.append(headers.parse_content_type(content_type))
+        self._available_types.append(parsed)
         self._handlers[content_type] = handler
 
     def get(self, content_type, default=None):

--- a/sprockets/mixins/mediatype/transcoders.py
+++ b/sprockets/mixins/mediatype/transcoders.py
@@ -192,6 +192,8 @@ class MsgPackTranscoder(handlers.BinaryContentHandler):
         +-------------------------------+-------------------------------+
         | :class:`collections.Mapping`  | `map family`_                 |
         +-------------------------------+-------------------------------+
+        | :class:`uuid.UUID`            | Converted to String           |
+        +-------------------------------+-------------------------------+
 
         .. _nil byte: https://github.com/msgpack/msgpack/blob/
            0b8f5ac67cdd130f4d4d4fe6afb839b989fdb86a/spec.md#formats-nil
@@ -217,6 +219,15 @@ class MsgPackTranscoder(handlers.BinaryContentHandler):
 
         if isinstance(datum, self.PACKABLE_TYPES):
             return datum
+
+        if isinstance(datum, uuid.UUID):
+            datum = str(datum)
+
+        if hasattr(datum, 'isoformat'):
+            datum = datum.isoformat()
+
+        if isinstance(datum, bytes):
+            datum = datum.decode('utf-8')
 
         if isinstance(datum, str):
             return datum

--- a/sprockets/mixins/mediatype/transcoders.py
+++ b/sprockets/mixins/mediatype/transcoders.py
@@ -27,7 +27,7 @@ class BinaryWrapper(bytes):
     Since :class:`bytes` is a synonym for :class:`str` in Python 2,
     you cannot distinguish between something that should be binary
     and something that should be encoded as a string.  This is a
-    problem in formats such as `msgpack`_ where binary data and
+    problem in formats `such as msgpack`_ where binary data and
     strings are encoded differently.  The :class:`MsgPackTranscoder`
     accomodates this by trying to UTF-8 encode a :class:`str` instance
     and falling back to binary encoding if the transcode fails.
@@ -36,7 +36,7 @@ class BinaryWrapper(bytes):
     this class.  The transcoder will then treat it as a binary payload
     instead of trying to detect whether it is a string or not.
 
-    .. _msgpack: http://msgpack.org
+    .. _such as msgpack: http://msgpack.org
 
     """
     pass
@@ -154,10 +154,10 @@ class MsgPackTranscoder(handlers.BinaryContentHandler):
         is passed directly to the ``BinaryContentHandler`` initializer.
 
     This transcoder uses the `umsgpack`_ library to encode and decode
-    objects according to the `msgpack`_ format.
+    objects according to the `msgpack format`_.
 
     .. _umsgpack: https://github.com/vsergeev/u-msgpack-python
-    .. _msgpack: http://msgpack.org/index.html
+    .. _msgpack format: http://msgpack.org/index.html
 
     """
     if sys.version_info[0] < 3:
@@ -255,6 +255,8 @@ class MsgPackTranscoder(handlers.BinaryContentHandler):
         .. _map family: https://github.com/msgpack/msgpack/blob/
            0b8f5ac67cdd130f4d4d4fe6afb839b989fdb86a/spec.md
            #mapping-format-family
+        .. _bin family: https://github.com/msgpack/msgpack/blob/
+           0b8f5ac67cdd130f4d4d4fe6afb839b989fdb86a/spec.md#bin-format-family
 
         """
         if datum is None:

--- a/sprockets/mixins/mediatype/transcoders.py
+++ b/sprockets/mixins/mediatype/transcoders.py
@@ -1,0 +1,56 @@
+"""Bundled media type transcoders."""
+import json
+import uuid
+
+from sprockets.mixins.mediatype import handlers
+
+
+class JSONTranscoder(handlers.TextContentHandler):
+    """
+    JSON transcoder instance.
+
+    :param str content_type: the content type that this encoder instance
+        implements. If omitted, ``application/json`` is used. This is
+        passed directly to the ``TextContentHandler`` initializer.
+    :param str default_encoding: the encoding to use if none is specified.
+        If omitted, this defaults to ``utf-8``. This is passed directly to
+        the ``TextContentHandler`` initializer.
+
+    .. attribute:: dump_options
+
+       Keyword parameters that are passed to :func:`json.dumps` when
+       :meth:`.dumps` is called.
+
+    .. attribute:: load_options
+
+       Keyword parameters that are passed to :func:`json.loads` when
+       :meth:`.loads` is called.
+
+    """
+
+    def __init__(self, content_type='application/json',
+                 default_encoding='utf-8'):
+        super(JSONTranscoder, self).__init__(content_type, self.dumps,
+                                             self.loads, default_encoding)
+        self.dump_options = {}
+        self.load_options = {}
+
+    def dumps(self, obj):
+        """
+        Dump a :class:`object` instance into a JSON :class:`str`
+
+        :param object obj: the object to dump
+        :return: the JSON representation of :class:`object`
+
+        """
+        return json.dumps(obj, **self.dump_options)
+
+    def loads(self, str_repr):
+        """
+        Transform :class:`str` into an :class:`object` instance.
+
+        :param str str_repr: the UNICODE representation of an object
+        :return: the decoded :class:`object` representation
+
+        """
+        return json.loads(str_repr, **self.load_options)

--- a/tests.py
+++ b/tests.py
@@ -313,3 +313,9 @@ class MsgPackTranscoderTests(unittest.TestCase):
         dumped = self.transcoder.packb(data)
         self.assertEqual(self.transcoder.unpackb(dumped), data)
         self.assertEqual(dumped, pack_bytes(data.tobytes()))
+
+    def test_that_utf8_values_can_be_forced_to_bytes(self):
+        data = b'a ascii value'
+        dumped = self.transcoder.packb(transcoders.BinaryWrapper(data))
+        self.assertEqual(self.transcoder.unpackb(dumped), data)
+        self.assertEqual(dumped, pack_bytes(data))

--- a/tests.py
+++ b/tests.py
@@ -1,9 +1,29 @@
+import base64
+import datetime
 import json
+import os
+import sys
+import unittest
+import uuid
 
 from tornado import testing
 import msgpack
 
+from sprockets.mixins.mediatype import transcoders
 import examples
+
+
+class UTC(datetime.tzinfo):
+    ZERO = datetime.timedelta(0)
+
+    def utcoffset(self, dt):
+        return self.ZERO
+
+    def dst(self, dt):
+        return self.ZERO
+
+    def tzname(self, dt):
+        return 'UTC'
 
 
 class SendResponseTests(testing.AsyncHTTPTestCase):
@@ -66,3 +86,51 @@ class GetRequestBodyTests(testing.AsyncHTTPTestCase):
                               headers={'Content-Type': 'application/msgpack'})
         self.assertEqual(response.code, 200)
         self.assertEqual(json.loads(response.body.decode('utf-8')), body)
+
+
+class JSONTranscoderTests(unittest.TestCase):
+
+    def setUp(self):
+        super(JSONTranscoderTests, self).setUp()
+        self.transcoder = transcoders.JSONTranscoder()
+
+    def test_that_uuids_are_dumped_as_strings(self):
+        obj = {'id': uuid.uuid4()}
+        dumped = self.transcoder.dumps(obj)
+        self.assertEqual(dumped.replace(' ', ''), '{"id":"%s"}' % obj['id'])
+
+    def test_that_datetimes_are_dumped_in_isoformat(self):
+        obj = {'now': datetime.datetime.now()}
+        dumped = self.transcoder.dumps(obj)
+        self.assertEqual(dumped.replace(' ', ''),
+                         '{"now":"%s"}' % obj['now'].isoformat())
+
+    def test_that_tzaware_datetimes_include_tzoffset(self):
+        obj = {'now': datetime.datetime.now().replace(tzinfo=UTC())}
+        self.assertTrue(obj['now'].isoformat().endswith('+00:00'))
+        dumped = self.transcoder.dumps(obj)
+        self.assertEqual(dumped.replace(' ', ''),
+                         '{"now":"%s"}' % obj['now'].isoformat())
+
+    @unittest.skipIf(sys.version_info[0] == 2, 'bytes unsupported on python 2')
+    def test_that_bytes_are_base64_encoded(self):
+        bin = bytes(os.urandom(127))
+        dumped = self.transcoder.dumps({'bin': bin})
+        self.assertEqual(
+            dumped, '{"bin":"%s"}' % base64.b64encode(bin).decode('ASCII'))
+
+    def test_that_bytearrays_are_base64_encoded(self):
+        bin = bytearray(os.urandom(127))
+        dumped = self.transcoder.dumps({'bin': bin})
+        self.assertEqual(
+            dumped, '{"bin":"%s"}' % base64.b64encode(bin).decode('ASCII'))
+
+    def test_that_memoryviews_are_base64_encoded(self):
+        bin = memoryview(os.urandom(127))
+        dumped = self.transcoder.dumps({'bin': bin})
+        self.assertEqual(
+            dumped, '{"bin":"%s"}' % base64.b64encode(bin).decode('ASCII'))
+
+    def test_that_unhandled_objects_raise_type_error(self):
+        with self.assertRaises(TypeError):
+            self.transcoder.dumps(object())

--- a/tests.py
+++ b/tests.py
@@ -240,6 +240,14 @@ class ContentFunctionTests(unittest.TestCase):
         self.assertIs(transcoder._dumps, json.dumps)
         self.assertIs(transcoder._loads, json.loads)
 
+    def test_that_add_text_content_type_discards_charset_parameter(self):
+        content.add_text_content_type(self.context,
+                                      'application/json;charset=UTF-8', 'utf8',
+                                      json.dumps, json.loads)
+        settings = content.ContentSettings.from_application(self.context)
+        transcoder = settings['application/json']
+        self.assertIsInstance(transcoder, handlers.TextContentHandler)
+
 
 class MsgPackTranscoderTests(unittest.TestCase):
 

--- a/tests.py
+++ b/tests.py
@@ -9,7 +9,7 @@ import uuid
 from tornado import testing
 import msgpack
 
-from sprockets.mixins.mediatype import transcoders
+from sprockets.mixins.mediatype import content, transcoders
 import examples
 
 
@@ -134,3 +134,30 @@ class JSONTranscoderTests(unittest.TestCase):
     def test_that_unhandled_objects_raise_type_error(self):
         with self.assertRaises(TypeError):
             self.transcoder.dumps(object())
+
+
+class ContentSettingsTests(unittest.TestCase):
+
+    def test_that_from_application_creates_instance(self):
+        class Context(object):
+            pass
+
+        context = Context()
+        settings = content.ContentSettings.from_application(context)
+        self.assertIs(content.ContentSettings.from_application(context),
+                      settings)
+
+    def test_that_handler_listed_in_available_content_types(self):
+        settings = content.ContentSettings()
+        settings['application/json'] = object()
+        self.assertEqual(len(settings.available_content_types), 1)
+        self.assertEqual(settings.available_content_types[0].content_type,
+                         'application')
+        self.assertEqual(settings.available_content_types[0].content_subtype,
+                         'json')
+
+    def test_that_handler_is_not_overwritten(self):
+        settings = content.ContentSettings()
+        settings['application/json'] = handler = object()
+        settings['application/json'] = object()
+        self.assertIs(settings.get('application/json'), handler)

--- a/tests.py
+++ b/tests.py
@@ -194,6 +194,26 @@ class ContentSettingsTests(unittest.TestCase):
         settings['application/json'] = object()
         self.assertIs(settings.get('application/json'), handler)
 
+    def test_that_registered_content_types_are_normalized(self):
+        settings = content.ContentSettings()
+        handler = object()
+        settings['application/json; VerSion=foo; type=WhatEver'] = handler
+        self.assertIs(settings['application/json; type=whatever; version=foo'],
+                      handler)
+        self.assertIn('application/json; type=whatever; version=foo',
+                      (str(c) for c in settings.available_content_types))
+
+    def test_that_normalized_content_types_do_not_overwrite(self):
+        settings = content.ContentSettings()
+        settings['application/json; charset=UTF-8'] = handler = object()
+        settings['application/json; charset=utf-8'] = object()
+        self.assertEqual(len(settings.available_content_types), 1)
+        self.assertEqual(settings.available_content_types[0].content_type,
+                         'application')
+        self.assertEqual(settings.available_content_types[0].content_subtype,
+                         'json')
+        self.assertEqual(settings['application/json; charset=utf-8'], handler)
+
 
 class ContentFunctionTests(unittest.TestCase):
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist = py27,py34,py35,pypy
 indexserver =
 	default = https://pypi.python.org/simple
 toxworkdir = build/tox
-skip_unknown_interpreters = true
+skip_missing_interpreters = true
 
 [testenv]
 deps =


### PR DESCRIPTION
This PR adds support for transcoder classes in addition to the simple function-based handlers that currently exist.  Internally, I switched the `add_binary_content_type` and `add_text_content_type` functions to use the new transcoder interface.