### PR TITLE
Return 400 when body decode fails.

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -6,10 +6,11 @@ Version History
 - Repackage from a module into a package.  Distributing raw modules inside
   of a namespace package is unreliable and questionably correct.
 - Add :func:`sprockets.mixins.mediatype.content.add_transcoder`.
-- Add :class:`sprockets.mixins.mediatype.transcoders.JSONTranscoder`
-- Add :class:`sprockets.mixins.mediatype.transcoders.MsgPackTranscoder`
-- Add :class:`sprockets.mixins.mediatype.transcoders.BinaryWrapper`
+- Add :class:`sprockets.mixins.mediatype.transcoders.JSONTranscoder`.
+- Add :class:`sprockets.mixins.mediatype.transcoders.MsgPackTranscoder`.
+- Add :class:`sprockets.mixins.mediatype.transcoders.BinaryWrapper`.
 - Normalize registered MIME types.
+- Raise a 400 status when content body decoding fails.
 
 `1.0.4`_ (14 Sep 2015)
 ----------------------

--- a/tests.py
+++ b/tests.py
@@ -121,6 +121,14 @@ class GetRequestBodyTests(testing.AsyncHTTPTestCase):
         self.assertEqual(response.code, 200)
         self.assertEqual(json.loads(response.body.decode('utf-8')), body)
 
+    def test_that_invalid_data_returns_400(self):
+        response = self.fetch(
+            '/', method='POST', headers={'Content-Type': 'application/json'},
+            body=('<?xml version="1.0"?><methodCall><methodName>echo'
+                  '</methodName><params><param><value><str>Hi</str></value>'
+                  '</param></params></methodCall>').encode('utf-8'))
+        self.assertEqual(response.code, 400)
+
 
 class JSONTranscoderTests(unittest.TestCase):
 


### PR DESCRIPTION
This PR changes the `ContentMixin` so that it reliably returns a client error when body decoding fails.  Currently, exceptions raised by the underlying decoder are propagated as-is to the request handler which requires that it handle the union of all possible exceptions which is just wrong.  Of the [registered status codes], [400 Bad Request] seemed most appropriate to me.  [422 Unprocessable Entity] from WebDAV is a close second except that it is reserved for syntactically valid entities.

[registered status codes]: http://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
[400 Bad Request]: http://tools.ietf.org/html/rfc7231#section-6.5.1
[422 Unprocessable Entity]: http://tools.ietf.org/html/rfc4918#section-11.2