### PR TITLE
Remove _mark_deprecated wrapper.

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -1,6 +1,11 @@
 Version History
 ===============
 
+`2.0.1`_ (29 Feb 2016)
+----------------------
+- Removed deprecation wrapper since it seems to cause really interesting
+  problems including the much feared meta-class error.
+
 `2.0.0`_ (24 Feb 2016)
 ----------------------
 - Repackage from a module into a package.  Distributing raw modules inside

--- a/sprockets/mixins/mediatype/__init__.py
+++ b/sprockets/mixins/mediatype/__init__.py
@@ -21,25 +21,8 @@ except ImportError as error:  # pragma no cover
     set_default_content_type = _error_closure
 
 
-def _mark_deprecated(func):
-    msg = '{0}.{1} is deprecated, use {0}.content.{1} instead'.format(
-        'sprockets.mixins.mediatype', func.__name__)
-
-    @functools.wraps(func)
-    def wrapper(*args, **kwargs):
-        warnings.warn(msg, category=DeprecationWarning)
-        return func(*args, **kwargs)
-
-    return wrapper
-
-add_binary_content_type = _mark_deprecated(add_binary_content_type)
-add_text_content_type = _mark_deprecated(add_text_content_type)
-set_default_content_type = _mark_deprecated(set_default_content_type)
-ContentMixin = _mark_deprecated(ContentMixin)
-ContentSettings = _mark_deprecated(ContentSettings)
-
-version_info = (2, 0, 0)
+version_info = (2, 0, 1)
 __version__ = '.'.join(str(v) for v in version_info)
-__all__ = ('ContentMixin', 'ContentSettings', 'add_binary_content_type',
+__all__ = ['ContentMixin', 'ContentSettings', 'add_binary_content_type',
            'add_text_content_type', 'set_default_content_type',
-           'version_info', '__version__')
+           'version_info', '__version__']


### PR DESCRIPTION
This seems to cause a bunch of problems with downstream packages with little or no gain.