### PR TITLE
Set the Vary header.

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -1,6 +1,10 @@
 Version History
 ===============
 
+`Next Release`_
+---------------
+- Set the _`Vary` header if we are setting the content type.
+
 `2.0.1`_ (29 Feb 2016)
 ----------------------
 - Removed deprecation wrapper since it seems to cause really interesting
@@ -38,10 +42,13 @@ Version History
 ---------------------
 - Initial Release
 
-.. _Next Release: https://github.com/sprockets/sprockets.http/compare/2.0.0...HEAD
+.. _Next Release: https://github.com/sprockets/sprockets.http/compare/2.0.1...HEAD
+.. _2.0.1: https://github.com/sprockets/sprockets.http/compare/2.0.0...2.0.1
 .. _2.0.0: https://github.com/sprockets/sprockets.http/compare/1.0.4...2.0.0
 .. _1.0.4: https://github.com/sprockets/sprockets.http/compare/1.0.3...1.0.4
 .. _1.0.3: https://github.com/sprockets/sprockets.http/compare/1.0.2...1.0.3
 .. _1.0.2: https://github.com/sprockets/sprockets.http/compare/1.0.1...1.0.2
 .. _1.0.1: https://github.com/sprockets/sprockets.http/compare/1.0.0...1.0.1
 .. _1.0.0: https://github.com/sprockets/sprockets.http/compare/0.0.0...1.0.0
+
+.. _Vary: http://tools.ietf.org/html/rfc7234#section-4.1

--- a/sprockets/mixins/mediatype/content.py
+++ b/sprockets/mixins/mediatype/content.py
@@ -303,4 +303,5 @@ class ContentMixin(object):
         content_type, data_bytes = handler.to_bytes(body)
         if set_content_type:
             self.set_header('Content-Type', content_type)
+            self.add_header('Vary', 'Accept')
         self.write(data_bytes)

--- a/tests.py
+++ b/tests.py
@@ -95,6 +95,12 @@ class SendResponseTests(testing.AsyncHTTPTestCase):
         self.assertEqual(response.headers['Content-Type'],
                          'application/json; charset="utf-8"')
 
+    def test_that_vary_header_is_set(self):
+        response = self.fetch('/', method='POST', body=umsgpack.packb({}),
+                              headers={'Content-Type': 'application/msgpack'})
+        self.assertEqual(response.code, 200)
+        self.assertEqual(response.headers['Vary'], 'Accept')
+
 
 class GetRequestBodyTests(testing.AsyncHTTPTestCase):
 


### PR DESCRIPTION
This PR sets the [Vary] HTTP header to inform caches that our responses will vary based on what the client requests with the [Accept] header.  Without this, caches will assume that a cached response can be used even if the Accept header differs.

**Additional Reading** _(just in case you are stuck in a meeting)_
- https://www.varnish-cache.org/docs/3.0/tutorial/vary.html
- http://mark.koli.ch/understanding-the-http-vary-header-and-caching-proxies-squid-etc
- http://asm89.github.io/2012/09/26/context-aware-http-caching.html

[Accept]: http://tools.ietf.org/html/rfc7231#section-5.3.2
[Vary]: http://tools.ietf.org/html/rfc7234#section-4.1