### PR TITLE
Add functions to install & retrieve ContentSettings from application

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,6 +12,25 @@ This mix-in adds two methods to a ``tornado.web.RequestHandler`` instance:
 - ``send_response(object)``: serializes the response into the content type
   requested by the ``Accept`` header.
 
+Before adding support for specific content types, you SHOULD install the
+content settings into your ``tornado.web.Application`` instance.  If you
+don't install the content settings, then an instance will be created for
+you by the mix-in; however, the created instance will be empty.  You
+should already have a function that creates the ``Application`` instance.
+If you don't, now is a good time to add one.
+
+.. code-block:: python
+
+   from sprockets.mixins.mediatype import content
+   from tornado import web
+
+   def make_application():
+       application = web.Application([
+           # insert your handlers here
+       ])
+       content.install(application, 'application/json', 'utf-8')
+       return application
+
 Support for a content types is enabled by calling ``add_binary_content_type``,
 ``add_text_content_type`` or the ``add_transcoder`` functions with the
 ``tornado.web.Application`` instance, the content type, encoding and decoding
@@ -29,6 +48,7 @@ functions as parameters:
            # insert your handlers here
        ])
 
+       content.install(application, 'application/json', 'utf-8')
        content.add_text_content_type(application,
                                      'application/json', 'utf-8',
                                      json.dumps, json.loads)
@@ -52,6 +72,7 @@ types:
            # insert your handlers here
        ])
 
+       content.install(application, 'application/json', 'utf-8')
        content.add_transcoder(application, transcoders.JSONTranscoder())
 
        return application

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -9,6 +9,10 @@ Content Type Handling
 
 Content Type Registration
 -------------------------
+.. autofunction:: install
+
+.. autofunction:: get_settings
+
 .. autofunction:: set_default_content_type
 
 .. autofunction:: add_binary_content_type

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -4,6 +4,7 @@ Version History
 ---------------
 - Add :func:`sprockets.mixins.mediatype.content.install`.
 - Add :func:`sprockets.mixins.mediatype.content.get_settings`.
+- Deprecate :meth:`sprockets.mixins.mediatype.content.ContentSettings.from_application`.
 
 `2.1.0`_ (16 Mar 2016)
 ----------------------

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -1,5 +1,9 @@
 Version History
 ===============
+`Next Release`_
+---------------
+- Add :func:`sprockets.mixins.mediatype.content.install`.
+- Add :func:`sprockets.mixins.mediatype.content.get_settings`.
 
 `2.1.0`_ (16 Mar 2016)
 ----------------------

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -47,14 +47,14 @@ Version History
 ---------------------
 - Initial Release
 
-.. _Next Release: https://github.com/sprockets/sprockets.http/compare/2.1.0...HEAD
-.. _2.1.0: https://github.com/sprockets/sprockets.http/compare/2.0.1...2.1.0
-.. _2.0.1: https://github.com/sprockets/sprockets.http/compare/2.0.0...2.0.1
-.. _2.0.0: https://github.com/sprockets/sprockets.http/compare/1.0.4...2.0.0
-.. _1.0.4: https://github.com/sprockets/sprockets.http/compare/1.0.3...1.0.4
-.. _1.0.3: https://github.com/sprockets/sprockets.http/compare/1.0.2...1.0.3
-.. _1.0.2: https://github.com/sprockets/sprockets.http/compare/1.0.1...1.0.2
-.. _1.0.1: https://github.com/sprockets/sprockets.http/compare/1.0.0...1.0.1
-.. _1.0.0: https://github.com/sprockets/sprockets.http/compare/0.0.0...1.0.0
+.. _Next Release: https://github.com/sprockets/sprockets.mixins.media_type/compare/2.1.0...HEAD
+.. _2.1.0: https://github.com/sprockets/sprockets.mixins.media_type/compare/2.0.1...2.1.0
+.. _2.0.1: https://github.com/sprockets/sprockets.mixins.media_type/compare/2.0.0...2.0.1
+.. _2.0.0: https://github.com/sprockets/sprockets.mixins.media_type/compare/1.0.4...2.0.0
+.. _1.0.4: https://github.com/sprockets/sprockets.mixins.media_type/compare/1.0.3...1.0.4
+.. _1.0.3: https://github.com/sprockets/sprockets.mixins.media_type/compare/1.0.2...1.0.3
+.. _1.0.2: https://github.com/sprockets/sprockets.mixins.media_type/compare/1.0.1...1.0.2
+.. _1.0.1: https://github.com/sprockets/sprockets.mixins.media_type/compare/1.0.0...1.0.1
+.. _1.0.0: https://github.com/sprockets/sprockets.mixins.media_type/compare/0.0.0...1.0.0
 
 .. _Vary: http://tools.ietf.org/html/rfc7234#section-4.1

--- a/docs/static/custom.css
+++ b/docs/static/custom.css
@@ -1,4 +1,21 @@
 @import url("alabaster.css");
 h1.logo {
   font-size: 12pt;
+  overflow-wrap: normal;
+  word-wrap: normal;
+  overflow: hidden;
+  margin-right: -25px; /* works together with div.body padding-left */
+}
+div.body {padding-left: 30px;}
+th.field-name {hyphens: none; -webkit-hyphens: none; -ms-hyphens: none;}
+div.document {width: 90%;}
+/* support small screens too! */
+@media screen and (max-width: 1000px) {
+  div.sphinxsidebar {display: none;}
+  div.document {width: 100%!important;}
+  div.bodywrapper {margin-left: 0;}
+  div.highlight pre {margin-right: -30px;}
+}
+@media screen and (min-width: 1000px) {
+  div.bodywrapper {margin-left: default;}
 }

--- a/docs/static/custom.css
+++ b/docs/static/custom.css
@@ -19,3 +19,14 @@ div.document {width: 90%;}
 @media screen and (min-width: 1000px) {
   div.bodywrapper {margin-left: default;}
 }
+/* hanging indent for class names
+ * would use "text-indent: 2em hanging" if it were supported everywhere
+ */
+dl.class > dt, dl.function > dt {
+	text-indent: -4em;
+	padding-left: 4em;
+}
+/* add some space to wrap nicely */
+span.sig-paren::after {
+	content: " ";
+}

--- a/tests.py
+++ b/tests.py
@@ -30,7 +30,8 @@ class UTC(datetime.tzinfo):
 
 class Context(object):
     """Super simple class to call setattr on"""
-    pass
+    def __init__(self):
+        self.settings = {}
 
 
 def pack_string(obj):
@@ -261,6 +262,26 @@ class ContentFunctionTests(unittest.TestCase):
         settings = content.ContentSettings.from_application(self.context)
         transcoder = settings['application/json']
         self.assertIsInstance(transcoder, handlers.TextContentHandler)
+
+    def test_that_install_creates_settings(self):
+        settings = content.install(self.context, 'application/json', 'utf8')
+        self.assertIsNotNone(settings)
+        self.assertEqual(settings.default_content_type, 'application/json')
+        self.assertEqual(settings.default_encoding, 'utf8')
+
+    def test_that_get_settings_returns_none_when_no_settings(self):
+        settings = content.get_settings(self.context)
+        self.assertIsNone(settings)
+
+    def test_that_get_settings_returns_installed_settings(self):
+        settings = content.install(self.context, 'application/xml', 'utf8')
+        other_settings = content.get_settings(self.context)
+        self.assertIs(settings, other_settings)
+
+    def test_that_get_settings_will_create_instance_if_requested(self):
+        settings = content.get_settings(self.context, force_instance=True)
+        self.assertIsNotNone(settings)
+        self.assertIs(content.get_settings(self.context), settings)
 
 
 class MsgPackTranscoderTests(unittest.TestCase):

--- a/tests.py
+++ b/tests.py
@@ -187,13 +187,6 @@ class JSONTranscoderTests(unittest.TestCase):
 
 class ContentSettingsTests(unittest.TestCase):
 
-    def test_that_from_application_creates_instance(self):
-
-        context = Context()
-        settings = content.ContentSettings.from_application(context)
-        self.assertIs(content.ContentSettings.from_application(context),
-                      settings)
-
     def test_that_handler_listed_in_available_content_types(self):
         settings = content.ContentSettings()
         settings['application/json'] = object()
@@ -237,29 +230,30 @@ class ContentFunctionTests(unittest.TestCase):
         self.context = Context()
 
     def test_that_add_binary_content_type_creates_binary_handler(self):
+        settings = content.install(self.context,
+                                   'application/octet-stream')
         content.add_binary_content_type(self.context,
                                         'application/vnd.python.pickle',
                                         pickle.dumps, pickle.loads)
-        settings = content.ContentSettings.from_application(self.context)
         transcoder = settings['application/vnd.python.pickle']
         self.assertIsInstance(transcoder, handlers.BinaryContentHandler)
         self.assertIs(transcoder._pack, pickle.dumps)
         self.assertIs(transcoder._unpack, pickle.loads)
 
     def test_that_add_text_content_type_creates_text_handler(self):
+        settings = content.install(self.context, 'application/json')
         content.add_text_content_type(self.context, 'application/json', 'utf8',
                                       json.dumps, json.loads)
-        settings = content.ContentSettings.from_application(self.context)
         transcoder = settings['application/json']
         self.assertIsInstance(transcoder, handlers.TextContentHandler)
         self.assertIs(transcoder._dumps, json.dumps)
         self.assertIs(transcoder._loads, json.loads)
 
     def test_that_add_text_content_type_discards_charset_parameter(self):
+        settings = content.install(self.context, 'application/json', 'utf-8')
         content.add_text_content_type(self.context,
                                       'application/json;charset=UTF-8', 'utf8',
                                       json.dumps, json.loads)
-        settings = content.ContentSettings.from_application(self.context)
         transcoder = settings['application/json']
         self.assertIsInstance(transcoder, handlers.TextContentHandler)
 


### PR DESCRIPTION
This PR adds the `sprockets.mixins.mediatype..content.install` and `sprockets.mixins.mediatype.content.get_settings` functions.  This first configures a `ContentSettings` object and installs it into anything that looks like a `tornado.web.Application` object -- *anything* is defined as *having a dictionary attribute named `settings`*.  The latter function, `get_settings`, retrieves a previously installed `ContentSettings` object from a `tornado.web.Application` object.  The existing code was refactored to use the new methods.