### PR TITLE
Metadata bumps for 2.2.0.

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -1,7 +1,7 @@
 Version History
 ===============
-`Next Release`_
----------------
+`2.2.0`_ (7 Jun 2017)
+---------------------
 - Add :func:`sprockets.mixins.mediatype.content.install`.
 - Add :func:`sprockets.mixins.mediatype.content.get_settings`.
 - Deprecate :meth:`sprockets.mixins.mediatype.content.ContentSettings.from_application`.
@@ -47,7 +47,8 @@ Version History
 ---------------------
 - Initial Release
 
-.. _Next Release: https://github.com/sprockets/sprockets.mixins.media_type/compare/2.1.0...HEAD
+.. _Next Release: https://github.com/sprockets/sprockets.mixins.media_type/compare/2.2.0...HEAD
+.. _2.2.0: https://github.com/sprockets/sprockets.mixins.media_type/compare/2.1.0...2.2.0
 .. _2.1.0: https://github.com/sprockets/sprockets.mixins.media_type/compare/2.0.1...2.1.0
 .. _2.0.1: https://github.com/sprockets/sprockets.mixins.media_type/compare/2.0.0...2.0.1
 .. _2.0.0: https://github.com/sprockets/sprockets.mixins.media_type/compare/1.0.4...2.0.0

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -5,6 +5,7 @@ Version History
 - Add :func:`sprockets.mixins.mediatype.content.install`.
 - Add :func:`sprockets.mixins.mediatype.content.get_settings`.
 - Deprecate :meth:`sprockets.mixins.mediatype.content.ContentSettings.from_application`.
+- Update to ietfparse 1.4.
 
 `2.1.0`_ (16 Mar 2016)
 ----------------------

--- a/sprockets/mixins/mediatype/__init__.py
+++ b/sprockets/mixins/mediatype/__init__.py
@@ -25,7 +25,7 @@ except ImportError as error:  # pragma no cover
     set_default_content_type = _error_closure
 
 
-version_info = (2, 1, 0)
+version_info = (2, 2, 0)
 __version__ = '.'.join(str(v) for v in version_info)
 __all__ = ['ContentMixin', 'ContentSettings', 'add_binary_content_type',
            'add_text_content_type', 'set_default_content_type',


### PR DESCRIPTION
This release adds the `content.install` function.  This was previously done inside of `add_transcoder`, `add_text_content_type` and the like.  This change should be completely interoperable with the 2.1.0 release.