### PR TITLE
Use ietfparse.headers.parse_accept

### DIFF
--- a/requires/installation.txt
+++ b/requires/installation.txt
@@ -1,2 +1,2 @@
-ietfparse>=1.2.2,<2
+ietfparse>=1.4,<2
 tornado>=3.2,<5

--- a/sprockets/mixins/mediatype/content.py
+++ b/sprockets/mixins/mediatype/content.py
@@ -309,7 +309,7 @@ class ContentMixin(object):
         """Figure out what content type will be used in the response."""
         if self._best_response_match is None:
             settings = get_settings(self.application, force_instance=True)
-            acceptable = headers.parse_http_accept_header(
+            acceptable = headers.parse_accept(
                 self.request.headers.get(
                     'Accept',
                     settings.default_content_type


### PR DESCRIPTION
Starting with ietfparse 1.3.0, parse_http_accept_header was marked as deprecated.