### PR TITLE
Pin ietfparse < 1.5

### DIFF
--- a/requires/installation.txt
+++ b/requires/installation.txt
@@ -1,2 +1,2 @@
-ietfparse>=1.4,<2
+ietfparse>=1.4,<1.5
 tornado>=3.2,<5


### PR DESCRIPTION
Breaking behavior was introduced in 1.5 which breaks this modules
handling of content types with suffixes.
https://github.com/sprockets/sprockets.mixins.media_type/issues/17