### PR TITLE
Add HTMLTranscoder and a few nits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ install:
   - pip install codecov -r requires/development.txt
 script:
   - nosetests
-  - python setup.py build_sphinx
   - python setup.py check
   - flake8
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
   - 3.7
 install:
   - pip install codecov -r requires/development.txt
+  - pip install codecov -r requires/installation.txt
 script:
   - nosetests
   - python setup.py check

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -1,9 +1,15 @@
 Version History
 ===============
 
+`3.0.0`_ (1 Dec 2018)
+---------------------
+- Drop support for Python < 3.5
+- Drop support for Tornado < 5.0
+- Add :class:`sprockets.mixins.mediatype.transcoders.HTMLTranscoder`
+
 `2.2.2`_ (7 Apr 2018)
 ---------------------
-- Add support for Python 3.5 throug 3.7
+- Add support for Python 3.5 through 3.7
 - Add support for Tornado < 6
 
 `2.2.1`_ (12 Apr 2018)
@@ -58,7 +64,8 @@ Version History
 ---------------------
 - Initial Release
 
-.. _Next Release: https://github.com/sprockets/sprockets.mixins.media_type/compare/2.2.2...HEAD
+.. _Next Release: https://github.com/sprockets/sprockets.mixins.media_type/compare/3.0.0...HEAD
+.. _3.0.0: https://github.com/sprockets/sprockets.mixins.media_type/compare/2.2.2...3.0.0
 .. _2.2.2: https://github.com/sprockets/sprockets.mixins.media_type/compare/2.2.1...2.2.2
 .. _2.2.1: https://github.com/sprockets/sprockets.mixins.media_type/compare/2.2.0...2.2.1
 .. _2.2.0: https://github.com/sprockets/sprockets.mixins.media_type/compare/2.1.0...2.2.0

--- a/requires/development.txt
+++ b/requires/development.txt
@@ -1,3 +1,2 @@
--e .[msgpack]
 -r docs.txt
 -r testing.txt

--- a/requires/testing.txt
+++ b/requires/testing.txt
@@ -2,3 +2,5 @@ coverage==4.5.2
 flake8==3.6.0
 nose==1.3.7
 tox==3.5.3
+setuptools_scm==3.1.0
+u-msgpack-python>=2.5.0,<3

--- a/sprockets/mixins/mediatype/transcoders.py
+++ b/sprockets/mixins/mediatype/transcoders.py
@@ -2,6 +2,7 @@
 Bundled media type transcoders.
 
 - :class:`.JSONTranscoder` implements JSON encoding/decoding
+- :class:`.HTMLTranscoder` implements HTML encoding/decoding
 - :class:`.MsgPackTranscoder` implements msgpack encoding/decoding
 
 """
@@ -115,6 +116,49 @@ class JSONTranscoder(handlers.TextContentHandler):
         raise TypeError('{!r} is not JSON serializable'.format(obj))
 
 
+class HTMLTranscoder(handlers.TextContentHandler):
+    """
+    HTML transcoder instance.
+
+    :param str content_type: the content type that this encoder instance
+        implements. If omitted, ``application/html`` is used. This is
+        passed directly to the ``TextContentHandler`` initializer.
+    :param str default_encoding: the encoding to use if none is specified.
+        If omitted, this defaults to ``utf-8``. This is passed directly to
+        the ``TextContentHandler`` initializer.
+
+    """
+    def __init__(self, content_type='text/html', default_encoding='utf-8'):
+        super(HTMLTranscoder, self).__init__(
+            content_type, self.dumps, self.loads, default_encoding)
+
+    @staticmethod
+    def dumps(value):
+        """
+        Just pass through the value if it's a string, otherwise dump it as
+        JSON.
+
+        :param mixed value: The value to possibly transform or pass through
+        :rtype: value
+
+        """
+        if not isinstance(value, (bytes, str)):
+            return '<html><body><pre>{}</pre></body></html>'.format(
+                json.dumps(value, indent=2))
+        return value
+
+    @staticmethod
+    def loads(value):
+        """
+        Just pass through the value.
+
+        :param mixed value: The value that is being passed through
+        :rtype: value
+
+        """
+        return value
+
+
 class MsgPackTranscoder(handlers.BinaryContentHandler):
     """
     Msgpack Transcoder instance.
@@ -136,7 +180,6 @@ class MsgPackTranscoder(handlers.BinaryContentHandler):
         if umsgpack is None:
             raise RuntimeError('Cannot import MsgPackTranscoder, '
                                'umsgpack is not available')
-
         super().__init__(content_type, self.packb, self.unpackb)
 
     def packb(self, data):

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,8 @@
 [tox]
 envlist = py35,py36,py37
-indexserver =
-	default = https://pypi.python.org/simple
 toxworkdir = build/tox
 skip_missing_interpreters = true
 
 [testenv]
-deps =
-    -e .[msgpack]
-    -r requires/testing.txt
+deps = -r requires/testing.txt
 commands = nosetests []


### PR DESCRIPTION
- Add the HTMLTranscoder class, an opinionated wrapper for sending HTML content
- Fix tox configuration so it works with the setuptools_scm change on my machine
- Remove the UTC class from testing since it's Python 3 only and use datetime.timezone.utc instead